### PR TITLE
Add options to operator-linebreak rule.

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -46,6 +46,8 @@ rules:
   operator-linebreak:
     - error
     - before
+    - overrides:
+        =: after
   padding-line-between-statements:
     - error
     - blankLine: always


### PR DESCRIPTION
## Why

* Update `operator-linebreak` rule for `typedEnv`.

* See #9

## How

* To write below code.
```
module.exports = /** @type {{
  API_HOST?: string,
  API_KEY?: string,
}} */ (Environment.getEnv())
```
