### PR TITLE
🐛 Resolve type of `globalThis.constructorSpy`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,7 @@
+import {
+  ConstructorSpy,
+} from '@openreachtech/jest-constructor-spy'
+
+declare global {
+  var constructorSpy: ConstructorSpy
+}


### PR DESCRIPTION
## Why

* Close #141

## How

* Add `types/index.d.ts`
